### PR TITLE
Submission timestamp support

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -130,6 +130,13 @@
                     <h2>Message Format</h2>
                     <p>JSON structure for certificate update messages</p>
                 </div>
+                <p style="margin-bottom: 1rem; color: var(--text-muted);">
+                    Two timestamps appear in each message: <code>seen</code> is the wall-clock time this server
+                    processed the entry, while <code>submission_timestamp</code> is the moment the CT log itself
+                    accepted the certificate and issued a Signed Certificate Timestamp (SCT) — as defined by
+                    <a href="https://www.rfc-editor.org/rfc/rfc6962#section-3.1" target="_blank" rel="noopener">RFC 6962 §3.1</a>.
+                    Both are Unix timestamps (seconds since epoch, with millisecond precision).
+                </p>
                 <div class="code-example" style="max-width: 900px;">
                     <div class="code-example-header">
                         <span class="lang">JSON</span>
@@ -174,6 +181,7 @@
     "<span class="str">chain</span>": [...],  <span class="cm">// full-stream only</span>
     "<span class="str">cert_index</span>": <span class="var">1234567890</span>,
     "<span class="str">seen</span>": <span class="var">1703808000.123</span>,
+    "<span class="str">submission_timestamp</span>": <span class="var">1703721600.456</span>,  <span class="cm">// when the CT log accepted this cert (RFC 6962 §3.1)</span>
     "<span class="str">source</span>": {
       "<span class="str">url</span>": "<span class="str">ct.googleapis.com/logs/argon2025</span>",
       "<span class="str">name</span>": "<span class="str">Google Argon 2025</span>"

--- a/src/ct/parser.rs
+++ b/src/ct/parser.rs
@@ -41,6 +41,10 @@ const OID_ED25519: Oid<'static> = oid!(1.3.101.112);
 pub struct ParsedEntry {
     pub update_type: Cow<'static, str>,
     pub leaf_cert: LeafCert,
+    /// CT log timestamp from the leaf_input MerkleTreeLeaf structure (RFC 6962).
+    /// Bytes 2–9 of the decoded leaf_input, interpreted as a uint64 big-endian
+    /// milliseconds value, converted to seconds with millisecond precision.
+    pub timestamp: f64,
     /// Raw extra_data bytes and the offset where chain parsing should begin.
     /// Chain parsing is deferred so that duplicate certificates (caught by the
     /// dedup filter) never pay the cost of DER-parsing 2-4 chain certs.
@@ -64,16 +68,32 @@ pub fn parse_leaf_input(leaf_input: &str, extra_data: &str) -> Option<ParsedEntr
         return None;
     }
 
+    // The length check above (< 15) guarantees at least 15 bytes, so indexing
+    // into [2..10] (the 8-byte timestamp) and [10..12] (the entry type) is safe.
+    // RFC 6962 MerkleTreeLeaf: byte 0 = version, byte 1 = leaf_type,
+    // bytes 2–9 = uint64 big-endian timestamp (milliseconds since Unix epoch).
+    let ts_ms = u64::from_be_bytes([
+        leaf_bytes[2],
+        leaf_bytes[3],
+        leaf_bytes[4],
+        leaf_bytes[5],
+        leaf_bytes[6],
+        leaf_bytes[7],
+        leaf_bytes[8],
+        leaf_bytes[9],
+    ]);
+    let timestamp = ts_ms as f64 / 1000.0;
+
     let entry_type = u16::from_be_bytes([leaf_bytes[10], leaf_bytes[11]]);
 
     match entry_type {
-        0 => parse_x509_entry(&leaf_bytes, extra_bytes),
-        1 => parse_precert_entry(extra_bytes),
+        0 => parse_x509_entry(&leaf_bytes, extra_bytes, timestamp),
+        1 => parse_precert_entry(extra_bytes, timestamp),
         _ => None,
     }
 }
 
-fn parse_x509_entry(leaf_bytes: &[u8], extra_bytes: Vec<u8>) -> Option<ParsedEntry> {
+fn parse_x509_entry(leaf_bytes: &[u8], extra_bytes: Vec<u8>, timestamp: f64) -> Option<ParsedEntry> {
     if leaf_bytes.len() < 15 {
         return None;
     }
@@ -94,12 +114,13 @@ fn parse_x509_entry(leaf_bytes: &[u8], extra_bytes: Vec<u8>) -> Option<ParsedEnt
     Some(ParsedEntry {
         update_type: Cow::Borrowed("X509LogEntry"),
         leaf_cert,
+        timestamp,
         chain_extra_bytes: extra_bytes,
         chain_offset: 0,
     })
 }
 
-fn parse_precert_entry(extra_bytes: Vec<u8>) -> Option<ParsedEntry> {
+fn parse_precert_entry(extra_bytes: Vec<u8>, timestamp: f64) -> Option<ParsedEntry> {
     // RFC 6962: extra_data for precert contains:
     // - 3 bytes: pre-certificate length
     // - pre-certificate (full X509 with CT poison extension)
@@ -125,6 +146,7 @@ fn parse_precert_entry(extra_bytes: Vec<u8>) -> Option<ParsedEntry> {
     Some(ParsedEntry {
         update_type: Cow::Borrowed("PrecertLogEntry"),
         leaf_cert,
+        timestamp,
         chain_extra_bytes: extra_bytes,
         chain_offset,
     })

--- a/src/ct/parser.rs
+++ b/src/ct/parser.rs
@@ -41,10 +41,13 @@ const OID_ED25519: Oid<'static> = oid!(1.3.101.112);
 pub struct ParsedEntry {
     pub update_type: Cow<'static, str>,
     pub leaf_cert: LeafCert,
-    /// CT log timestamp from the leaf_input MerkleTreeLeaf structure (RFC 6962).
-    /// Bytes 2–9 of the decoded leaf_input, interpreted as a uint64 big-endian
-    /// milliseconds value, converted to seconds with millisecond precision.
-    pub timestamp: f64,
+    /// Submission timestamp: the moment the CT log issued the SCT for this entry
+    /// (RFC 6962 §3.1, `TimestampedEntry.timestamp`).  Extracted from bytes 2–9
+    /// of the decoded `leaf_input` as a uint64 big-endian milliseconds value and
+    /// converted to seconds with millisecond precision.  This records when the
+    /// certificate was submitted to and accepted by the log — not when the cert
+    /// was issued or when the Merkle tree was updated.
+    pub submission_timestamp: f64,
     /// Raw extra_data bytes and the offset where chain parsing should begin.
     /// Chain parsing is deferred so that duplicate certificates (caught by the
     /// dedup filter) never pay the cost of DER-parsing 2-4 chain certs.
@@ -82,18 +85,18 @@ pub fn parse_leaf_input(leaf_input: &str, extra_data: &str) -> Option<ParsedEntr
         leaf_bytes[8],
         leaf_bytes[9],
     ]);
-    let timestamp = ts_ms as f64 / 1000.0;
+    let submission_timestamp = ts_ms as f64 / 1000.0;
 
     let entry_type = u16::from_be_bytes([leaf_bytes[10], leaf_bytes[11]]);
 
     match entry_type {
-        0 => parse_x509_entry(&leaf_bytes, extra_bytes, timestamp),
-        1 => parse_precert_entry(extra_bytes, timestamp),
+        0 => parse_x509_entry(&leaf_bytes, extra_bytes, submission_timestamp),
+        1 => parse_precert_entry(extra_bytes, submission_timestamp),
         _ => None,
     }
 }
 
-fn parse_x509_entry(leaf_bytes: &[u8], extra_bytes: Vec<u8>, timestamp: f64) -> Option<ParsedEntry> {
+fn parse_x509_entry(leaf_bytes: &[u8], extra_bytes: Vec<u8>, submission_timestamp: f64) -> Option<ParsedEntry> {
     if leaf_bytes.len() < 15 {
         return None;
     }
@@ -114,13 +117,13 @@ fn parse_x509_entry(leaf_bytes: &[u8], extra_bytes: Vec<u8>, timestamp: f64) -> 
     Some(ParsedEntry {
         update_type: Cow::Borrowed("X509LogEntry"),
         leaf_cert,
-        timestamp,
+        submission_timestamp,
         chain_extra_bytes: extra_bytes,
         chain_offset: 0,
     })
 }
 
-fn parse_precert_entry(extra_bytes: Vec<u8>, timestamp: f64) -> Option<ParsedEntry> {
+fn parse_precert_entry(extra_bytes: Vec<u8>, submission_timestamp: f64) -> Option<ParsedEntry> {
     // RFC 6962: extra_data for precert contains:
     // - 3 bytes: pre-certificate length
     // - pre-certificate (full X509 with CT poison extension)
@@ -146,7 +149,7 @@ fn parse_precert_entry(extra_bytes: Vec<u8>, timestamp: f64) -> Option<ParsedEnt
     Some(ParsedEntry {
         update_type: Cow::Borrowed("PrecertLogEntry"),
         leaf_cert,
-        timestamp,
+        submission_timestamp,
         chain_extra_bytes: extra_bytes,
         chain_offset,
     })

--- a/src/ct/static_ct.rs
+++ b/src/ct/static_ct.rs
@@ -724,6 +724,7 @@ pub async fn run_static_ct_watcher(log: CtLog, ctx: WatcherContext) {
                                         cert_index,
                                         cert_link,
                                         seen,
+                                        timestamp: leaf.timestamp as f64 / 1000.0,
                                         source: Arc::clone(&source),
                                     },
                                 };

--- a/src/ct/static_ct.rs
+++ b/src/ct/static_ct.rs
@@ -26,7 +26,7 @@ pub struct Checkpoint {
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct TileLeaf {
-    pub timestamp: u64,
+    pub submission_timestamp: u64,
     pub entry_type: u16,
     pub cert_der: Vec<u8>,
     pub is_precert: bool,
@@ -179,7 +179,7 @@ fn parse_one_leaf(data: &[u8], offset: &mut usize) -> Option<TileLeaf> {
         return None;
     }
 
-    let timestamp = u64::from_be_bytes(data[*offset..*offset + 8].try_into().ok()?);
+    let submission_timestamp = u64::from_be_bytes(data[*offset..*offset + 8].try_into().ok()?);
     *offset += 8;
 
     let entry_type = u16::from_be_bytes(data[*offset..*offset + 2].try_into().ok()?);
@@ -259,7 +259,7 @@ fn parse_one_leaf(data: &[u8], offset: &mut usize) -> Option<TileLeaf> {
         }
 
         return Some(TileLeaf {
-            timestamp,
+            submission_timestamp,
             entry_type,
             cert_der,
             is_precert,
@@ -297,7 +297,7 @@ fn parse_one_leaf(data: &[u8], offset: &mut usize) -> Option<TileLeaf> {
     }
 
     Some(TileLeaf {
-        timestamp,
+        submission_timestamp,
         entry_type,
         cert_der,
         is_precert,
@@ -724,7 +724,7 @@ pub async fn run_static_ct_watcher(log: CtLog, ctx: WatcherContext) {
                                         cert_index,
                                         cert_link,
                                         seen,
-                                        timestamp: leaf.timestamp as f64 / 1000.0,
+                                        submission_timestamp: leaf.submission_timestamp as f64 / 1000.0,
                                         source: Arc::clone(&source),
                                     },
                                 };
@@ -983,7 +983,7 @@ mod tests {
 
         let leaves = parse_tile_leaves(&data);
         assert_eq!(leaves.len(), 1);
-        assert_eq!(leaves[0].timestamp, 1700000000000);
+        assert_eq!(leaves[0].submission_timestamp, 1700000000000);
         assert_eq!(leaves[0].entry_type, 0);
         assert!(!leaves[0].is_precert);
         assert_eq!(leaves[0].cert_der, cert);
@@ -1002,7 +1002,7 @@ mod tests {
 
         let leaves = parse_tile_leaves(&data);
         assert_eq!(leaves.len(), 1);
-        assert_eq!(leaves[0].timestamp, 1700000001000);
+        assert_eq!(leaves[0].submission_timestamp, 1700000001000);
         assert_eq!(leaves[0].entry_type, 1);
         assert!(leaves[0].is_precert);
         assert_eq!(leaves[0].cert_der, precert);
@@ -1023,16 +1023,16 @@ mod tests {
         let leaves = parse_tile_leaves(&data);
         assert_eq!(leaves.len(), 3);
 
-        assert_eq!(leaves[0].timestamp, 1000);
+        assert_eq!(leaves[0].submission_timestamp, 1000);
         assert!(!leaves[0].is_precert);
         assert_eq!(leaves[0].cert_der, b"cert1");
 
-        assert_eq!(leaves[1].timestamp, 2000);
+        assert_eq!(leaves[1].submission_timestamp, 2000);
         assert!(!leaves[1].is_precert);
         assert_eq!(leaves[1].cert_der, b"cert2");
         assert_eq!(leaves[1].chain_fingerprints.len(), 1);
 
-        assert_eq!(leaves[2].timestamp, 3000);
+        assert_eq!(leaves[2].submission_timestamp, 3000);
         assert!(leaves[2].is_precert);
         assert_eq!(leaves[2].cert_der, b"precert");
     }

--- a/src/ct/watcher.rs
+++ b/src/ct/watcher.rs
@@ -472,6 +472,7 @@ pub async fn run_watcher_with_cache(log: CtLog, ctx: WatcherContext) {
                                     cert_index,
                                     cert_link,
                                     seen,
+                                    timestamp: parsed.timestamp,
                                     source: Arc::clone(&source),
                                 },
                             };

--- a/src/ct/watcher.rs
+++ b/src/ct/watcher.rs
@@ -472,7 +472,7 @@ pub async fn run_watcher_with_cache(log: CtLog, ctx: WatcherContext) {
                                     cert_index,
                                     cert_link,
                                     seen,
-                                    timestamp: parsed.timestamp,
+                                    submission_timestamp: parsed.submission_timestamp,
                                     source: Arc::clone(&source),
                                 },
                             };

--- a/src/health.rs
+++ b/src/health.rs
@@ -149,6 +149,7 @@ pub async fn example_json() -> Json<CertificateMessage> {
             cert_index: 123456789,
             cert_link: "https://ct.googleapis.com/logs/us1/argon2025h2/ct/v1/get-entries?start=123456789&end=123456789".to_string(),
             seen: 1704067200.123,
+            timestamp: 1704000000.0,
             source: Arc::new(Source {
                 name: Arc::from("Google 'Argon2024' log"),
                 url: Arc::from("https://ct.googleapis.com/logs/argon2024"),

--- a/src/health.rs
+++ b/src/health.rs
@@ -149,7 +149,7 @@ pub async fn example_json() -> Json<CertificateMessage> {
             cert_index: 123456789,
             cert_link: "https://ct.googleapis.com/logs/us1/argon2025h2/ct/v1/get-entries?start=123456789&end=123456789".to_string(),
             seen: 1704067200.123,
-            timestamp: 1704000000.0,
+            submission_timestamp: 1704000000.0,
             source: Arc::new(Source {
                 name: Arc::from("Google 'Argon2024' log"),
                 url: Arc::from("https://ct.googleapis.com/logs/argon2024"),

--- a/src/models/certificate.rs
+++ b/src/models/certificate.rs
@@ -23,6 +23,9 @@ pub struct CertificateData {
     pub cert_index: u64,
     pub cert_link: String,
     pub seen: f64,
+    /// CT log timestamp extracted from the leaf_input MerkleTreeLeaf structure
+    /// (RFC 6962, bytes 2–9), in seconds since Unix epoch with millisecond precision.
+    pub timestamp: f64,
     pub source: Arc<Source>,
 }
 
@@ -220,6 +223,7 @@ struct LiteData<'a> {
     cert_index: u64,
     cert_link: &'a str,
     seen: f64,
+    timestamp: f64,
     source: &'a Arc<Source>,
 }
 
@@ -269,6 +273,7 @@ impl CertificateMessage {
                 cert_index: self.data.cert_index,
                 cert_link: &self.data.cert_link,
                 seen: self.data.seen,
+                timestamp: self.data.timestamp,
                 source: &self.data.source,
             },
         }
@@ -318,6 +323,7 @@ mod tests {
                 cert_index: 12345,
                 cert_link: "https://ct.example.com/entry/12345".into(),
                 seen: 1700000000.0,
+                timestamp: 1700000000.0,
                 source: Arc::new(Source {
                     name: Arc::from("Test Log"),
                     url: Arc::from("https://ct.example.com/"),

--- a/src/models/certificate.rs
+++ b/src/models/certificate.rs
@@ -23,9 +23,9 @@ pub struct CertificateData {
     pub cert_index: u64,
     pub cert_link: String,
     pub seen: f64,
-    /// CT log timestamp extracted from the leaf_input MerkleTreeLeaf structure
-    /// (RFC 6962, bytes 2–9), in seconds since Unix epoch with millisecond precision.
-    pub timestamp: f64,
+    /// Submission timestamp: the moment the CT log issued the SCT for this entry
+    /// (RFC 6962 §3.1), in seconds since Unix epoch with millisecond precision.
+    pub submission_timestamp: f64,
     pub source: Arc<Source>,
 }
 
@@ -223,7 +223,7 @@ struct LiteData<'a> {
     cert_index: u64,
     cert_link: &'a str,
     seen: f64,
-    timestamp: f64,
+    submission_timestamp: f64,
     source: &'a Arc<Source>,
 }
 
@@ -273,7 +273,7 @@ impl CertificateMessage {
                 cert_index: self.data.cert_index,
                 cert_link: &self.data.cert_link,
                 seen: self.data.seen,
-                timestamp: self.data.timestamp,
+                submission_timestamp: self.data.submission_timestamp,
                 source: &self.data.source,
             },
         }
@@ -323,7 +323,7 @@ mod tests {
                 cert_index: 12345,
                 cert_link: "https://ct.example.com/entry/12345".into(),
                 seen: 1700000000.0,
-                timestamp: 1700000000.0,
+                submission_timestamp: 1700000000.0,
                 source: Arc::new(Source {
                     name: Arc::from("Test Log"),
                     url: Arc::from("https://ct.example.com/"),


### PR DESCRIPTION
Hey,

This is a great project, thanks a lot for putting together a Rust implementation.

I noticed that, like certstream and certstream-go, this version doesn’t include what (at least to me) is a pretty important CT log field: the submission timestamp. That value tells us when the certificate was submitted to the log, which helps gauge how “fresh” it is and estimate the maximum merge delay.

It would be great to see this included and eventually merged upstream.

Disclaimer: I used Copilot to help with this, since Rust isn’t my native language 🙂

Best,
Raffaele